### PR TITLE
fix_create_account_crash_on_empty_password

### DIFF
--- a/src/Raytha.Application/Login/Commands/CompleteForgotPassword.cs
+++ b/src/Raytha.Application/Login/Commands/CompleteForgotPassword.cs
@@ -30,7 +30,7 @@ public class CompleteForgotPassword
             RuleFor(x => x.Id).NotEmpty();
             RuleFor(x => x).Custom((request, context) =>
             {
-                if (request.NewPassword.Length < PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH)
+                if (string.IsNullOrEmpty(request.NewPassword) || request.NewPassword.Length < PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH)
                 {
                     context.AddFailure("NewPassword", $"Password must be at least {PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH} characters.");
                     return;

--- a/src/Raytha.Application/Login/Commands/CreateUser.cs
+++ b/src/Raytha.Application/Login/Commands/CreateUser.cs
@@ -36,7 +36,7 @@ public class CreateUser
             RuleFor(x => x.EmailAddress).NotEmpty().EmailAddress();
             RuleFor(x => x).Custom((request, context) =>
             {
-                if (request.Password.Length < PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH)
+                if (string.IsNullOrEmpty(request.Password) || request.Password.Length < PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH)
                 {
                     context.AddFailure("Password", $"Password must be at least {PasswordUtility.PASSWORD_MIN_CHARACTER_LENGTH} characters.");
                     return;


### PR DESCRIPTION
## Fixes
added to check not empty string in condition.

## modification place
- src/Raytha.Application/Login/Commands/CreateUser.cs
- src/Raytha.Application/Login/Commands/CompleteForgotPassword.cs